### PR TITLE
Set display name of worker processes to layer

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -37,6 +37,7 @@ function elapsedTime() {
 
 function handleLoadMsg(msg) {
   context.name = msg.name;
+  process.title = context.name;
   context.startTime = Date.now();
 
   readStream(msg.directory, msg.name, function(features) {


### PR DESCRIPTION
Using the [process.title](https://nodejs.org/api/process.html#process_process_title) method, it's possible to change the title of processes as shown in tools
like `ps`, `top`, and `htop`.

One limitation is that the name can't be longer than the existing one
(see linked documentation), so right now the process name is simply the
layer, which may be confusing in that it won't in any way indicate that
the process is a nodejs process. However the ability to gague CPU usage
of individual workers is valuable enough.

Here's a screenshot
![admin-lookup](https://cloud.githubusercontent.com/assets/111716/13714894/7b6dbbba-e79f-11e5-8259-b484dd458931.png)
