### PR TITLE
Lookup country by id instead of polygon

### DIFF
--- a/server.js
+++ b/server.js
@@ -11,9 +11,10 @@ createPIPService(function (err, pipService) {
       res.json(results);
     });
 
-    app.listen(port, function () {
-      logger.info('PIP service listening on port ', port);
-    });
-
   });
+
+  app.listen(port, function () {
+    logger.info('PIP service listening on port ', port);
+  });
+
 });

--- a/src/components/extractFields.js
+++ b/src/components/extractFields.js
@@ -9,7 +9,8 @@ module.exports.create = function() {
         Id: wofData.properties['wof:id'],
         Name: getName(wofData),
         Placetype: wofData.properties['wof:placetype'],
-        Hierarchy: wofData.properties['wof:hierarchy']
+        Hierarchy: wofData.properties['wof:hierarchy'],
+        ISO: wofData.properties['iso:country']
       },
       geometry: wofData.geometry
     };

--- a/src/components/extractFields.js
+++ b/src/components/extractFields.js
@@ -9,8 +9,7 @@ module.exports.create = function() {
         Id: wofData.properties['wof:id'],
         Name: getName(wofData),
         Placetype: wofData.properties['wof:placetype'],
-        Hierarchy: wofData.properties['wof:hierarchy'],
-        ISO: wofData.properties['iso:country']
+        Hierarchy: wofData.properties['wof:hierarchy']
       },
       geometry: wofData.geometry
     };

--- a/src/index.js
+++ b/src/index.js
@@ -21,14 +21,14 @@ var responseQueue = {};
 
 var defaultLayers = module.exports.defaultLayers = [
   'country', // 216
-  // 'county', // 18166
-  // 'dependency', // 39
-  // 'disputed', // 39
-  // 'localadmin', // 106880
-  // 'locality', // 160372
+  'county', // 18166
+  'dependency', // 39
+  'disputed', // 39
+  'localadmin', // 106880
+  'locality', // 160372
   'macrocounty', // 350
   'macroregion', // 82
-  // 'neighbourhood', // 62936
+  'neighbourhood', // 62936
   'region' // 4698
 ];
 

--- a/src/index.js
+++ b/src/index.js
@@ -71,6 +71,7 @@ module.exports.create = function createPIPService(layers, callback) {
             Object.keys(workers).forEach(function (layer) {
               workers[layer].kill();
             });
+            countryWorker.kill();
           },
           lookup: function (latitude, longitude, responseCallback, search_layers) {
             if (search_layers === undefined) {

--- a/src/index.js
+++ b/src/index.js
@@ -21,14 +21,14 @@ var responseQueue = {};
 
 var defaultLayers = module.exports.defaultLayers = [
   'country', // 216
-  'county', // 18166
-  'dependency', // 39
-  'disputed', // 39
-  'localadmin', // 106880
-  'locality', // 160372
+  // 'county', // 18166
+  // 'dependency', // 39
+  // 'disputed', // 39
+  // 'localadmin', // 106880
+  // 'locality', // 160372
   'macrocounty', // 350
   'macroregion', // 82
-  'neighbourhood', // 62936
+  // 'neighbourhood', // 62936
   'region' // 4698
 ];
 
@@ -74,20 +74,23 @@ module.exports.create = function createPIPService(layers, callback) {
             search_layers = _.intersection(search_layers, layers);
           }
 
-          // exclude country layer initially
-          search_layers = _.filter(search_layers, function(layer) { return layer !== 'country' } );
+          // exclude country layer initially since it performs poorly
+          var non_country_search_layers = _.filter(search_layers, function(layer) {
+            return layer !== 'country';
+          });
 
           var id = uid(10);
 
           responseQueue[id] = {
             results: [],
             latLon: {latitude: latitude, longitude: longitude},
-            search_layers: search_layers,
+            search_layers: non_country_search_layers,
             numberOfLayersCalled: 0,
-            responseCallback: responseCallback
+            responseCallback: responseCallback,
+            lookupCountryByIdHasBeenCalled: false
           };
 
-          search_layers.forEach(function(layer) {
+          non_country_search_layers.forEach(function(layer) {
             searchWorker(id, workers[layer], {latitude: latitude, longitude: longitude});
           });
         }
@@ -110,7 +113,7 @@ function startWorker(directory, layer, callback) {
 
   worker.on('message', function (msg) {
     if (msg.type === 'loaded') {
-      logger.info(msg, 'Worker ' + msg.name + ' just told me it loaded!');
+      logger.info(msg, 'Worker ' + msg.layer + ' just told me it loaded!');
       callback(null, worker);
     }
 
@@ -121,7 +124,7 @@ function startWorker(directory, layer, callback) {
 
   worker.send({
     type: 'load',
-    name: layer,
+    layer: layer,
     directory: directory
   });
 }
@@ -132,6 +135,14 @@ function searchWorker(id, worker, coords) {
     id: id,
     coords: coords
   })
+}
+
+function lookupCountryById(id, countryId) {
+  workers.country.send({
+    type: 'lookupById',
+    id: id,
+    countryId: countryId
+  });
 }
 
 function handleResults(msg) {
@@ -145,12 +156,76 @@ function handleResults(msg) {
   if (allLayersHaveBeenCalled(responseQueue[msg.id])) {
     if (countryLayerShouldBeCalled(responseQueue[msg.id], workers)) {
         searchWorker(msg.id, workers.country, responseQueue[msg.id].latLon);
+
+    } else if (lookupCountryByIdShouldBeCalled(responseQueue[msg.id])) {
+        // mark that lookupCountryById has already been called so it's not
+        //  called again if it returns nothing
+        responseQueue[msg.id].lookupCountryByIdHasBeenCalled = true;
+
+        lookupCountryById(msg.id, getId(responseQueue[msg.id].results));
+
     } else {
+      // all info has been gathered, so return
       responseQueue[msg.id].responseCallback(null, responseQueue[msg.id].results);
       delete responseQueue[msg.id];
+
     }
 
   }
+}
+
+// helper function that gets the id of the first result with a hierarchy country id
+// caveat:  this will produce inconsistent behavior if results have different
+//  hierarchy country id values (which shouldn't happen, otherwise it's bad data)
+//
+// it's safe to assume that at least one result has a hierarchy country id value
+//  since the call to `lookupCountryByIdShouldBeCalled` has already confirmed it
+//  and this function is called in combination
+function getId(results) {
+  for (var i = 0; i < results.length; i++) {
+    for (var j = 0; j < results[i].Hierarchy.length; j++) {
+      if (results[i].Hierarchy[j].hasOwnProperty('country_id')) {
+        return results[i].Hierarchy[j].country_id;
+      }
+    }
+  }
+
+}
+
+// helper function to determine if country should be looked up by id
+// returns `false` if:
+// 1.  there are no results (lat/lon is in the middle of an ocean)
+// 2.  no result has a hierarchy country id (shouldn't happen but guard against bad data)
+// 3.  lookupCountryByIdHasBeenCalled has already been called
+// 4.  there is already a result with a `country` Placetype
+//
+// in the general case, this function should return true because the country
+// polygon lookup is normally skipped for performance reasons but country needs
+// to be looked up anyway
+function lookupCountryByIdShouldBeCalled(q) {
+  // helper that returns true if at least one Hierarchy of a result has a `country_id` property
+  var hasCountryId = function(result) {
+    return result.Hierarchy.length > 0 &&
+            _.some(result.Hierarchy, function(h) { return h.hasOwnProperty('country_id')});
+  }
+
+  var isCountryPlacetype = function(result) {
+    return result.Placetype === 'country';
+  }
+
+  // don't call if no (or any) result has a country id
+  if (q.results.length === 0 || !_.some(q.results, hasCountryId)) {
+    return false;
+  }
+
+  // don't call lookupCountryById if it's already been called
+  if (q.lookupCountryByIdHasBeenCalled) {
+    return false;
+  }
+
+  // return true if there are no results with 'country' Placetype
+  return !_.some(q.results, isCountryPlacetype);
+
 }
 
 // helper to determine if all requested layers have been called

--- a/src/index.js
+++ b/src/index.js
@@ -62,12 +62,7 @@ module.exports.create = function createPIPService(layers, callback) {
       logger.info('PIP Service Loading Completed!!!');
 
       callback(null, {
-        end: function end() {
-          Object.keys(workers).forEach(function (layer) {
-            workers[layer].kill();
-          });
-          countryWorker.kill();
-        },
+        end: killAllWorkers,
         lookup: function (latitude, longitude, responseCallback, search_layers) {
           if (search_layers === undefined) {
             search_layers = layers;
@@ -101,6 +96,13 @@ module.exports.create = function createPIPService(layers, callback) {
   );
 
 };
+
+function killAllWorkers() {
+  Object.keys(workers).forEach(function (layer) {
+    workers[layer].kill();
+  });
+
+}
 
 function startWorker(directory, layer, callback) {
 

--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ module.exports.create = function createPIPService(layers, callback) {
     layers = defaultLayers;
   }
 
-  // load all workers, including country
+  // load all workers, including country, which is a special case
   async.forEach(layers.concat('country'), function (layer, done) {
       startWorker(directory, layer, function (err, worker) {
         workers[layer] = worker;

--- a/src/index.js
+++ b/src/index.js
@@ -16,21 +16,20 @@ var uid = require('uid');
 var _ = require('lodash');
 
 var workers = {};
-var countryWorker;
 
 var responseQueue = {};
 
 var defaultLayers = module.exports.defaultLayers = [
   //'continent',
-  // 'country', // 216
-  'county', // 18166
-  'dependency', // 39
-  'disputed', // 39
-  'localadmin', // 106880
-  'locality', // 160372
+  'country', // 216
+  // 'county', // 18166
+  // 'dependency', // 39
+  // 'disputed', // 39
+  // 'localadmin', // 106880
+  // 'locality', // 160372
   'macrocounty', // 350
   'macroregion', // 82
-  'neighbourhood', // 62936
+  // 'neighbourhood', // 62936
   'region' // 4698
 ];
 
@@ -54,55 +53,53 @@ module.exports.create = function createPIPService(layers, callback) {
     layers = defaultLayers;
   }
 
-  startWorker(directory, 'country', function(err, worker) {
-    countryWorker = worker;
+  async.forEach(layers, function (layer, done) {
+      startWorker(directory, layer, function (err, worker) {
+        workers[layer] = worker;
+        done();
+      });
+    },
+    function end() {
+      logger.info('PIP Service Loading Completed!!!');
 
-    async.forEach(layers, function (layer, done) {
-        startWorker(directory, layer, function (err, worker) {
-          workers[layer] = worker;
-          done();
-        });
-      },
-      function end() {
-        logger.info('PIP Service Loading Completed!!!');
-
-        callback(null, {
-          end: function end() {
-            Object.keys(workers).forEach(function (layer) {
-              workers[layer].kill();
-            });
-            countryWorker.kill();
-          },
-          lookup: function (latitude, longitude, responseCallback, search_layers) {
-            if (search_layers === undefined) {
-              search_layers = layers;
-            } else {
-              // take the intersection of the valid layers and the layers sent in
-              // so that if any layers are manually disabled for development
-              // everything still works. this also means invalid layers
-              // are silently ignored
-              search_layers = _.intersection(search_layers, layers);
-            }
-
-            var id = uid(10);
-
-            responseQueue[id] = {
-              results: [],
-              latLon: {latitude: latitude, longitude: longitude},
-              search_layers: search_layers,
-              resultCount: 0,
-              responseCallback: responseCallback
-            };
-
-            search_layers.forEach(function(layer) {
-              searchWorker(id, workers[layer], {latitude: latitude, longitude: longitude});
-            });
+      callback(null, {
+        end: function end() {
+          Object.keys(workers).forEach(function (layer) {
+            workers[layer].kill();
+          });
+          countryWorker.kill();
+        },
+        lookup: function (latitude, longitude, responseCallback, search_layers) {
+          if (search_layers === undefined) {
+            search_layers = layers;
+          } else {
+            // take the intersection of the valid layers and the layers sent in
+            // so that if any layers are manually disabled for development
+            // everything still works. this also means invalid layers
+            // are silently ignored
+            search_layers = _.intersection(search_layers, layers);
           }
-        });
-      }
-    );
 
-  });
+          // exclude country layer initially
+          search_layers = _.filter(search_layers, function(layer) { return layer !== 'country' } );
+
+          var id = uid(10);
+
+          responseQueue[id] = {
+            results: [],
+            latLon: {latitude: latitude, longitude: longitude},
+            search_layers: search_layers,
+            numberOfLayersCalled: 0,
+            responseCallback: responseCallback
+          };
+
+          search_layers.forEach(function(layer) {
+            searchWorker(id, workers[layer], {latitude: latitude, longitude: longitude});
+          });
+        }
+      });
+    }
+  );
 
 };
 
@@ -142,13 +139,11 @@ function handleResults(msg) {
   if (!_.isEmpty(msg.results) ) {
     responseQueue[msg.id].results.push(msg.results);
   }
-  responseQueue[msg.id].resultCount++;
+  responseQueue[msg.id].numberOfLayersCalled++;
 
-  if (responseQueue[msg.id].resultCount >= responseQueue[msg.id].search_layers.length) {
-    // check if country data got added
-    // if not, add it and figure out how to wait for its response
-    if (responseQueue[msg.id].results.length === 0 && !countryAlreadyCalled(responseQueue[msg.id])) {
-      searchWorker(msg.id, countryWorker, responseQueue[msg.id].latLon);
+  if (allLayersHaveBeenCalled(responseQueue[msg.id])) {
+    if (countryLayerShouldBeCalled(responseQueue[msg.id], workers)) {
+      searchWorker(msg.id, workers.country, responseQueue[msg.id].latLon);
     } else {
       responseQueue[msg.id].responseCallback(null, responseQueue[msg.id].results);
       delete responseQueue[msg.id];
@@ -157,8 +152,30 @@ function handleResults(msg) {
   }
 }
 
+// helper to determine if all requested layers have been called
+// need to check `>=` since country is initially excluded but counted when called
+function allLayersHaveBeenCalled(q) {
+  return q.numberOfLayersCalled >= q.search_layers.length;
+}
+
+// country layer should be called when the following 3 conditions have been met
+// 1. no other layers returned anything (when a point falls under no subcountry polygons)
+// 2. country layer has not already been called
+// 3. there is a country layer available (don't crash if it hasn't been loaded)
+function countryLayerShouldBeCalled(q, workers) {
+  return noNonCountryLayersReturned(q) &&
+          !countryAlreadyCalled(q) &&
+          workers.hasOwnProperty('country');
+}
+
+// helper to determine if any non-country layers returned results
+function noNonCountryLayersReturned(q) {
+  return q.results.length === 0;
+}
+
+// helper to determine if country layer has already been called
 function countryAlreadyCalled(q) {
-  return q.resultCount === q.search_layers.length+1;
+  return q.numberOfLayersCalled === q.search_layers.length+1;
 }
 
 function hasDataDirectory() {

--- a/src/index.js
+++ b/src/index.js
@@ -20,16 +20,15 @@ var workers = {};
 var responseQueue = {};
 
 var defaultLayers = module.exports.defaultLayers = [
-  //'continent',
   'country', // 216
-  // 'county', // 18166
-  // 'dependency', // 39
-  // 'disputed', // 39
-  // 'localadmin', // 106880
-  // 'locality', // 160372
+  'county', // 18166
+  'dependency', // 39
+  'disputed', // 39
+  'localadmin', // 106880
+  'locality', // 160372
   'macrocounty', // 350
   'macroregion', // 82
-  // 'neighbourhood', // 62936
+  'neighbourhood', // 62936
   'region' // 4698
 ];
 
@@ -143,7 +142,7 @@ function handleResults(msg) {
 
   if (allLayersHaveBeenCalled(responseQueue[msg.id])) {
     if (countryLayerShouldBeCalled(responseQueue[msg.id], workers)) {
-      searchWorker(msg.id, workers.country, responseQueue[msg.id].latLon);
+        searchWorker(msg.id, workers.country, responseQueue[msg.id].latLon);
     } else {
       responseQueue[msg.id].responseCallback(null, responseQueue[msg.id].results);
       delete responseQueue[msg.id];

--- a/src/worker.js
+++ b/src/worker.js
@@ -14,8 +14,7 @@ var context = {
   layer: '', // The name of this layer (eg, 'country', 'neighborhood').
   featureCollection: {
     features: []
-  },
-  byId: {} // this is only used by the `country` layer
+  }
 };
 
 /**
@@ -47,15 +46,12 @@ function handleLoadMsg(msg) {
     context.featureCollection.features = features;
     context.adminLookup = new PolygonLookup( context.featureCollection );
 
+    // load countries up into an object keyed on id
     if ('country' === context.layer) {
-      logger.info('going to load countries by id');
-
-      features.forEach(function(feature) {
-        context.byId[feature.properties.Id] = feature.properties;
-      });
-
-      logger.info('loaded ' + Object.keys(context.byId).length + ' countries');
-
+      context.byId = features.reduce(function(cumulative, feature) {
+        cumulative[feature.properties.Id] = feature.properties;
+        return cumulative;
+      }, {});
     }
 
     logger.info( 'Done loading ' + context.layer );
@@ -95,6 +91,9 @@ function handleLookupById(msg) {
 }
 
 // return a country layer or an empty object (country not found)
+// only process if this is the country worker
 function lookupById(id) {
-  return context.byId[id] || {};
+  if ('country' === context.layer) {
+    return context.byId[id] || {};
+  }
 }

--- a/test/components/extractFieldsTest.js
+++ b/test/components/extractFieldsTest.js
@@ -18,6 +18,7 @@ tape('extractFields tests', function(test) {
     input.properties['wof:name'] = 'Feature name';
     input.properties['wof:placetype'] = 'Feature placetype';
     input.properties['wof:hierarchy'] = 'Feature hierarchy';
+    input.properties['iso:country'] = 'Feature ISO';
 
     var expected = {
       properties: {
@@ -25,6 +26,7 @@ tape('extractFields tests', function(test) {
         Name: 'Feature name',
         Placetype: 'Feature placetype',
         Hierarchy: 'Feature hierarchy',
+        ISO: 'Feature ISO'
       },
       geometry: 'Geometry'
     };
@@ -55,6 +57,7 @@ tape('extractFields tests', function(test) {
         Name: 'a2_alt value',
         Placetype: 'county',
         Hierarchy: 'Feature hierarchy',
+        ISO: 'US'
       },
       geometry: undefined
     };
@@ -77,6 +80,7 @@ tape('extractFields tests', function(test) {
     input.properties['iso:country'] = 'non-US';
     input.properties['wof:placetype'] = 'county';
     input.properties['wof:hierarchy'] = 'Feature hierarchy';
+    input.properties['iso:country'] = 'Feature ISO';
     input.properties['qs:a2_alt'] = 'a2_alt value';
 
     var expected = {
@@ -85,6 +89,7 @@ tape('extractFields tests', function(test) {
         Name: 'Feature name',
         Placetype: 'county',
         Hierarchy: 'Feature hierarchy',
+        ISO: 'Feature ISO'
       },
       geometry: undefined
     };
@@ -107,6 +112,7 @@ tape('extractFields tests', function(test) {
     input.properties['iso:country'] = 'US';
     input.properties['wof:placetype'] = 'non-county';
     input.properties['wof:hierarchy'] = 'Feature hierarchy';
+    input.properties['iso:country'] = 'Feature ISO';
     input.properties['qs:a2_alt'] = 'a2_alt value';
 
     var expected = {
@@ -115,6 +121,7 @@ tape('extractFields tests', function(test) {
         Name: 'Feature name',
         Placetype: 'non-county',
         Hierarchy: 'Feature hierarchy',
+        ISO: 'Feature ISO'
       },
       geometry: undefined
     };
@@ -144,6 +151,7 @@ tape('extractFields tests', function(test) {
         Name: 'Feature name',
         Placetype: 'county',
         Hierarchy: 'Feature hierarchy',
+        ISO: 'US'
       },
       geometry: undefined
     };

--- a/test/components/extractFieldsTest.js
+++ b/test/components/extractFieldsTest.js
@@ -18,15 +18,13 @@ tape('extractFields tests', function(test) {
     input.properties['wof:name'] = 'Feature name';
     input.properties['wof:placetype'] = 'Feature placetype';
     input.properties['wof:hierarchy'] = 'Feature hierarchy';
-    input.properties['iso:country'] = 'Feature ISO';
 
     var expected = {
       properties: {
         Id: 17,
         Name: 'Feature name',
         Placetype: 'Feature placetype',
-        Hierarchy: 'Feature hierarchy',
-        ISO: 'Feature ISO'
+        Hierarchy: 'Feature hierarchy'
       },
       geometry: 'Geometry'
     };
@@ -56,8 +54,7 @@ tape('extractFields tests', function(test) {
         Id: 17,
         Name: 'a2_alt value',
         Placetype: 'county',
-        Hierarchy: 'Feature hierarchy',
-        ISO: 'US'
+        Hierarchy: 'Feature hierarchy'
       },
       geometry: undefined
     };
@@ -80,7 +77,6 @@ tape('extractFields tests', function(test) {
     input.properties['iso:country'] = 'non-US';
     input.properties['wof:placetype'] = 'county';
     input.properties['wof:hierarchy'] = 'Feature hierarchy';
-    input.properties['iso:country'] = 'Feature ISO';
     input.properties['qs:a2_alt'] = 'a2_alt value';
 
     var expected = {
@@ -88,8 +84,7 @@ tape('extractFields tests', function(test) {
         Id: 17,
         Name: 'Feature name',
         Placetype: 'county',
-        Hierarchy: 'Feature hierarchy',
-        ISO: 'Feature ISO'
+        Hierarchy: 'Feature hierarchy'
       },
       geometry: undefined
     };
@@ -112,7 +107,6 @@ tape('extractFields tests', function(test) {
     input.properties['iso:country'] = 'US';
     input.properties['wof:placetype'] = 'non-county';
     input.properties['wof:hierarchy'] = 'Feature hierarchy';
-    input.properties['iso:country'] = 'Feature ISO';
     input.properties['qs:a2_alt'] = 'a2_alt value';
 
     var expected = {
@@ -120,8 +114,7 @@ tape('extractFields tests', function(test) {
         Id: 17,
         Name: 'Feature name',
         Placetype: 'non-county',
-        Hierarchy: 'Feature hierarchy',
-        ISO: 'Feature ISO'
+        Hierarchy: 'Feature hierarchy'
       },
       geometry: undefined
     };
@@ -150,8 +143,7 @@ tape('extractFields tests', function(test) {
         Id: 17,
         Name: 'Feature name',
         Placetype: 'county',
-        Hierarchy: 'Feature hierarchy',
-        ISO: 'US'
+        Hierarchy: 'Feature hierarchy'
       },
       geometry: undefined
     };


### PR DESCRIPTION
The concepts in this code are a bit confusing but I've added tons of helper functions to make it clearer.  Initially this project would call all layers for polygon lookup, but unfortunately the sheer size of the country polygons was causing a 2.5x performance degradation in the consumer data importers.  

There are 2 basic concepts:

1.  No non-country layers returned anything so check the country layer to see if the lat/lon is at least in a country (think middle of the Sahara).  This seems unlikely, but execute for thoroughness.  
2.  For a lat/lon in the middle of Paris, other layers will have returned but country layer info is still needed even though the country layer was not queried.  The `country` worker supports a `byId` lookup so that the `countryId` from a sub-country layer can be used to quickly lookup the `country` layer info.  This is exclusively for performance reasons.  

