### PR TITLE
Remove functional tests from TravisCI runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ env:
   global:
     - CXX=g++-4.8
   matrix:
-    - TEST_SUITE=functional
     - TEST_SUITE=units
 script: "npm run $TEST_SUITE"
 addons:


### PR DESCRIPTION
Now that we have unit tests, and considering that the functional tests
never worked on Travis because they need full WOF data, we can just
disable them for now.

Maybe someday we can load a subset of WOF data and run them on Travis.