### PR TITLE
Use integers as ids for admin lookup requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "through2-filter": "^2.0.0",
     "through2-map": "^2.0.0",
     "through2-sink": "^1.0.0",
-    "uid": "0.0.2",
     "unbzip2-stream": "^1.0.8"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -12,9 +12,10 @@ var childProcess = require( 'child_process' );
 var logger = require( 'pelias-logger' ).get( 'wof-pip-service:master' );
 var peliasConfig = require( 'pelias-config' ).generate();
 var async = require('async');
-var uid = require('uid');
 var _ = require('lodash');
 
+
+var requestCount = 0;
 // worker processes keyed on layer
 var workers = {};
 
@@ -79,7 +80,8 @@ module.exports.create = function createPIPService(layers, callback) {
             search_layers = _.intersection(search_layers, layers);
           }
 
-          var id = uid(10);
+          var id = requestCount;
+          requestCount++;
 
           if (responseQueue.hasOwnProperty(id)) {
             var msg = "Tried to create responseQueue item with id " + id + " that is already present";


### PR DESCRIPTION
Using strings has a small chance of collisions, but over the length of our imports it is actually quite likely, and has been causing our builds to fail.

It turns out we don't really need a fancy uid, integers should be fine up to [10^15 or so](http://stackoverflow.com/questions/1848700/biggest-integer-that-can-be-stored-in-a-double).

[This script](https://gist.github.com/orangejulius/2272527b0974b26cfc26a6a7a8dd8a40) can be used to see how often collisions happen. On my machine it generates one every 50-150M tries.