### PR TITLE
Detect and warn on duplicate admin lookup IDs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -81,6 +81,12 @@ module.exports.create = function createPIPService(layers, callback) {
 
           var id = uid(10);
 
+          if (responseQueue.hasOwnProperty(id)) {
+            var msg = "Tried to create responseQueue item with id " + id + " that is already present";
+            logger.error(msg);
+            return responseCallback(null, []);
+          }
+
           // bookkeeping object that tracks the progress of the request
           responseQueue[id] = {
             results: [],
@@ -146,6 +152,11 @@ function lookupCountryById(id, countryId) {
 
 function handleResults(msg) {
   // logger.info('RESULTS:', JSON.stringify(msg, null, 2));
+
+  if (!responseQueue.hasOwnProperty(msg.id)) {
+    logger.error("tried to handle results for missing id " + msg.id);
+    return;
+  }
 
   if (!_.isEmpty(msg.results) ) {
     responseQueue[msg.id].results.push(msg.results);


### PR DESCRIPTION
There are two cases where the effect of duplicate IDs can be detected:
first when creating a new responseQueue object and the ID is already in
use, and when handleResults is called but the ID does not exist.

The first case is recoverable, it's easy to simply return no admin
lookup information.

The second is an error that will cause the build to fail (without having
the responseQueue object, the correct callback can't be found and
called, so the build will hang). However putting an error message here
can help with detection of strange situations if anything ever does
happen again.

Doing some testing with the uid length set to 4, which results in a huge number of duplicates, shows that the first case is sufficient to keep the build going, although of course individual records will have no admin info. Again, having both is nice to catch future, currently unanticipated issues.