### PR TITLE
added exception handling for invalid JSON in WOF data

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,9 @@
   "scripts": {
     "download": "node src/downloadData.js",
     "start": "PELIAS_CONFIG=${PWD}/config.json node server.js",
-    "functional": "PELIAS_CONFIG=${PWD}/config.json node test/functional.js",
+    "functional": "npm run functional",
     "test": "npm run units",
-    "units": "node test/test | tap-dot",
-    "functional": "npm run functional"
+    "units": "node test/test | tap-dot"
   },
   "author": "Mapzen",
   "license": "MIT",
@@ -29,6 +28,7 @@
     "polygon-lookup": "^1.0.2",
     "simplify-js": "^1.2.1",
     "tar-stream": "^1.3.1",
+    "through2": "^2.0.1",
     "through2-filter": "^2.0.0",
     "through2-map": "^2.0.0",
     "through2-sink": "^1.0.0",

--- a/src/components/loadJSON.js
+++ b/src/components/loadJSON.js
@@ -1,10 +1,11 @@
 var path = require('path');
-var map = require('through2-map');
+var through = require('through2');
+var logger = require( 'pelias-logger' ).get( 'wof-pip-service:loadJSON' );
 var fs = require('fs');
 
 module.exports.create = function(datapath) {
   // parse and return JSON contents
-  return map.obj(function(id, enc, callback) {
+  return through.obj(function(id, enc, next) {
     // id 123456789 -> data/123/456/789/123456789.geojson
     var filename = [
       datapath,
@@ -15,7 +16,14 @@ module.exports.create = function(datapath) {
       id + '.geojson']
     .join(path.sep);
 
-    return JSON.parse(fs.readFileSync(filename));
+    try {
+      this.push(JSON.parse(fs.readFileSync(filename)));
+    }
+    catch (e) {
+      logger.error('exception occured parsing ' + filename + ': ' + e);
+    }
+
+    next();
 
   });
 }

--- a/test/components/loadJSONTest.js
+++ b/test/components/loadJSONTest.js
@@ -36,4 +36,29 @@ tape('loadJSON tests', function(test) {
 
   });
 
+  test.test('invalid JSON should log an error and not pass along anything', function(t) {
+    var input = '123456789';
+
+    // create a directory to hold the temporary file
+    var tmpDirectory = ['data', '123', '456', '789'];
+    fs.mkdirsSync(tmpDirectory.join(path.sep));
+
+    // write the contents to a file
+    var filename = tmpDirectory.concat('123456789.geojson').join(path.sep);
+    fs.writeFileSync(filename, 'this is not json\n');
+
+    var loadJSON = require('../../src/components/loadJSON').create('.');
+
+    test_stream([input], loadJSON, function(err, actual) {
+      // cleanup the tmp directory
+      fs.removeSync(tmpDirectory[0]);
+
+      console.log(actual);
+
+      t.deepEqual(actual, [], 'nothing should have been passed along');
+      t.end();
+    });
+
+  });
+
 });


### PR DESCRIPTION
While rare, invalid JSON can creep into WOF data causing our WOF PiP service to fail load and never hit the "all data loaded" condition.  This change switches to a `through2` stream, logs an error when JSON is unparseable, and allows execution to continue without crashing.

Fixed #32 