### PR TITLE
added filter to only include "important" neighbourhoods

### DIFF
--- a/src/components/filterOutUnimportantNeighbourhoods.js
+++ b/src/components/filterOutUnimportantNeighbourhoods.js
@@ -1,5 +1,13 @@
 var filter = require('through2-filter');
 
+function isImportant(tier_locality) {
+  return tier_locality === 6 || tier_locality === 7;
+}
+
+function isFunky(is_funky) {
+  return is_funky !== undefined && is_funky === 1;
+}
+
 module.exports.create = function create() {
   return filter.obj(function(wofData) {
 
@@ -8,8 +16,9 @@ module.exports.create = function create() {
       return true;
     }
 
-    // only return true if the neighbourhood is important enough
-    return wofData.properties['mz:tier_locality'] === 7;
+    // only return true if the neighbourhood is important enough and isn't funky
+    return isImportant(wofData.properties['mz:tier_locality']) &&
+            !isFunky(wofData.properties['mz:is_funky']);
 
   });
 }

--- a/src/components/filterOutUnimportantNeighbourhoods.js
+++ b/src/components/filterOutUnimportantNeighbourhoods.js
@@ -1,9 +1,14 @@
 var filter = require('through2-filter');
 
+// tier_locality has values ranging from 1-7 with 1 being of highly suspect
+// validity (East Yoe, Red Lion, PA) and 7 being very important (Soho, New York City)
 function isImportant(tier_locality) {
   return tier_locality === 6 || tier_locality === 7;
 }
 
+// is_funky has value either 0 or 1 and describes the validity of the data
+// 0 should be interpreted as "from an authoritative and trusted source"
+// 1 should be interpreted as "from a highly suspect data source and shouldn't be consumed"
 function isFunky(is_funky) {
   return is_funky !== undefined && is_funky === 1;
 }
@@ -17,6 +22,10 @@ module.exports.create = function create() {
     }
 
     // only return true if the neighbourhood is important enough and isn't funky
+    // examples of tier_locality/is_funky:
+    // 7/0 - Soho, https://whosonfirst.mapzen.com/spelunker/id/85865687/#15/40.7235/-74.0057
+    // 7/1 - Baja Noe, https://whosonfirst.mapzen.com/spelunker/id/85887409/#15/37.7540/-122.4231
+    // 1/0 - East Yoe, https://whosonfirst.mapzen.com/spelunker/id/85816963/#12/39.9002/-76.6190
     return isImportant(wofData.properties['mz:tier_locality']) &&
             !isFunky(wofData.properties['mz:is_funky']);
 

--- a/src/components/filterOutUnimportantNeighbourhoods.js
+++ b/src/components/filterOutUnimportantNeighbourhoods.js
@@ -1,0 +1,15 @@
+var filter = require('through2-filter');
+
+module.exports.create = function create() {
+  return filter.obj(function(wofData) {
+
+    // if this isn't a neighbourhood, just include it
+    if (wofData.properties['wof:placetype'] !== 'neighbourhood') {
+      return true;
+    }
+
+    // only return true if the neighbourhood is important enough
+    return wofData.properties['mz:tier_locality'] === 7;
+
+  });
+}

--- a/src/readStream.js
+++ b/src/readStream.js
@@ -8,6 +8,7 @@ var extractFields = require('./components/extractFields');
 var simplifyGeometry = require('./components/simplifyGeometry');
 var isActiveRecord = require('./components/isActiveRecord');
 var filterOutNamelessRecords = require('./components/filterOutNamelessRecords');
+var filterOutUnimportantNeighbourhoods = require('./components/filterOutUnimportantNeighbourhoods');
 
 /*
   This function finds all the `latest` files in `meta/`, CSV parses them,
@@ -28,6 +29,7 @@ function readData(directory, layer, callback) {
     .pipe(loadJSON.create(directory))
     .pipe(isActiveRecord.create())
     .pipe(filterOutNamelessRecords.create())
+    .pipe(filterOutUnimportantNeighbourhoods.create())
     .pipe(extractFields.create())
     .pipe(simplifyGeometry.create())
     .pipe(sink.obj(function(feature) {

--- a/test/components/filterOutUnimportantNeighbourhoodsTest.js
+++ b/test/components/filterOutUnimportantNeighbourhoodsTest.js
@@ -1,0 +1,80 @@
+var tape = require('tape');
+var event_stream = require('event-stream');
+
+var filterOutUnimportantNeighbourhoods = require('../../src/components/filterOutUnimportantNeighbourhoods');
+
+function test_stream(input, testedStream, callback) {
+    var input_stream = event_stream.readArray(input);
+    var destination_stream = event_stream.writeArray(callback);
+
+    input_stream.pipe(testedStream).pipe(destination_stream);
+}
+
+tape('filterOutUnimportantNeighbourhoods', function(test) {
+  test.test('non-neighbourhood placetype should return true', function(t) {
+    var input = [
+      {
+        properties: { 'wof:placetype': 'locality', 'mz:tier_locality': 1 }
+      },
+      {
+        properties: { 'wof:placetype': 'localadmin', 'mz:tier_locality': 2 }
+      },
+      {
+        properties: { 'wof:placetype': 'region', 'mz:tier_locality': 3 }
+      },
+      {
+        properties: { 'wof:placetype': 'county', 'mz:tier_locality': 7 }
+      }
+    ];
+    var expected = input;
+
+    var filter = filterOutUnimportantNeighbourhoods.create();
+
+    test_stream(input, filter, function(err, actual) {
+      t.deepEqual(actual, expected, 'should have returned true');
+      t.end();
+    });
+
+  });
+
+  test.test('neighbourhood placetype with non-7 mz:tier_locality should return false', function(t) {
+    var input = [
+      {
+        properties: { 'wof:placetype': 'neighbourhood', 'mz:tier_locality': 1 }
+      },
+      {
+        properties: { 'wof:placetype': 'neighbourhood', 'mz:tier_locality': 2 }
+      },
+      {
+        properties: { 'wof:placetype': 'neighbourhood', 'mz:tier_locality': 3 }
+      },
+      {
+        properties: { 'wof:placetype': 'neighbourhood', 'mz:tier_locality': 4 }
+      },
+      {
+        properties: { 'wof:placetype': 'neighbourhood', 'mz:tier_locality': 5 }
+      },
+      {
+        properties: { 'wof:placetype': 'neighbourhood', 'mz:tier_locality': 6 }
+      },
+      {
+        properties: { 'wof:placetype': 'neighbourhood', 'mz:tier_locality': 7 }
+      },
+      {
+        properties: { 'wof:placetype': 'neighbourhood', 'mz:tier_locality': 8 }
+      }
+    ];
+
+    // only the placetype=neighbourhood and tier_locality=7 input should be returned
+    var expected = [input[6]];
+
+    var filter = filterOutUnimportantNeighbourhoods.create();
+
+    test_stream(input, filter, function(err, actual) {
+      t.deepEqual(actual, expected, 'should have returned true');
+      t.end();
+    });
+
+  });
+
+});

--- a/test/components/filterOutUnimportantNeighbourhoodsTest.js
+++ b/test/components/filterOutUnimportantNeighbourhoodsTest.js
@@ -77,6 +77,24 @@ tape('filterOutUnimportantNeighbourhoods', function(test) {
 
   });
 
+  test.test('neighbourhood placetype with undefined mz:tier_locality should return false', function(t) {
+    var input = [
+      {
+        properties: { 'wof:placetype': 'neighbourhood', 'mz:is_funky': 0 }
+      }
+    ];
+
+    var expected = [];
+
+    var filter = filterOutUnimportantNeighbourhoods.create();
+
+    test_stream(input, filter, function(err, actual) {
+      t.deepEqual(actual, expected, 'should have returned true');
+      t.end();
+    });
+
+  });
+
   test.test('neighbourhood placetype with 6 or 7 mz:tier_locality but mz:is_funky=1 should return false', function(t) {
     var input = [
       {

--- a/test/components/filterOutUnimportantNeighbourhoodsTest.js
+++ b/test/components/filterOutUnimportantNeighbourhoodsTest.js
@@ -37,7 +37,7 @@ tape('filterOutUnimportantNeighbourhoods', function(test) {
 
   });
 
-  test.test('neighbourhood placetype with non-7 mz:tier_locality should return false', function(t) {
+  test.test('neighbourhood placetype with non-6/7 mz:tier_locality should return false', function(t) {
     var input = [
       {
         properties: { 'wof:placetype': 'neighbourhood', 'mz:tier_locality': 1 }
@@ -66,7 +66,41 @@ tape('filterOutUnimportantNeighbourhoods', function(test) {
     ];
 
     // only the placetype=neighbourhood and tier_locality=7 input should be returned
-    var expected = [input[6]];
+    var expected = [input[5], input[6]];
+
+    var filter = filterOutUnimportantNeighbourhoods.create();
+
+    test_stream(input, filter, function(err, actual) {
+      t.deepEqual(actual, expected, 'should have returned true');
+      t.end();
+    });
+
+  });
+
+  test.test('neighbourhood placetype with 6 or 7 mz:tier_locality but mz:is_funky=1 should return false', function(t) {
+    var input = [
+      {
+        properties: { 'wof:placetype': 'neighbourhood', 'mz:tier_locality': 6, 'mz:is_funky': 0 }
+      },
+      {
+        properties: { 'wof:placetype': 'neighbourhood', 'mz:tier_locality': 7, 'mz:is_funky': 0 }
+      },
+      {
+        properties: { 'wof:placetype': 'neighbourhood', 'mz:tier_locality': 6, 'mz:is_funky': 1 }
+      },
+      {
+        properties: { 'wof:placetype': 'neighbourhood', 'mz:tier_locality': 7, 'mz:is_funky': 1 }
+      },
+      {
+        properties: { 'wof:placetype': 'neighbourhood', 'mz:tier_locality': 6 }
+      },
+      {
+        properties: { 'wof:placetype': 'neighbourhood', 'mz:tier_locality': 7 }
+      }
+    ];
+
+    // only the placetype=neighbourhood ,tier_locality=7, and non-funky inputs should be returned
+    var expected = [input[0], input[1], input[4], input[5]];
 
     var filter = filterOutUnimportantNeighbourhoods.create();
 

--- a/test/test.js
+++ b/test/test.js
@@ -5,3 +5,4 @@ require ('./components/loadJSONTest.js');
 require ('./components/simplifyGeometryTest.js');
 require ('./components/isActiveRecordTest.js');
 require ('./components/filterOutNamelessRecordsTest.js');
+require ('./components/filterOutUnimportantNeighbourhoodsTest.js');


### PR DESCRIPTION
~~DO NOT MERGE UNTIL WE TALK TO KELSO.~~

While performing admin lookups for OA/OSM addresses, "unimportant" neighbourhoods are ingested, resulting in addresses having neighbourhoods that don't traditionally.  There is a field in the WOF record properties called `mz:tier_locality` that appears to give an importance value to neighbourhoods that lines us with expectations.  The values range from 0 (completely unknown) to 7 for neighbourhoods in NYC, Long Island, San Francisco, northern New Jersey, and other very large cities.  This PR filters out neighbourhoods that not value 7.