### PR TITLE
switched from `edtf:superseded` to `wof:superseded_by`

### DIFF
--- a/src/components/isActiveRecord.js
+++ b/src/components/isActiveRecord.js
@@ -12,7 +12,9 @@ function isDeprecated(wofData) {
 }
 
 function isSuperseded(wofData) {
-  return !_.isEmpty(_.trim(wofData.properties['edtf:superseded']));
+  return wofData.properties.hasOwnProperty('wof:superseded_by') &&
+          _.isArray(wofData.properties['wof:superseded_by']) &&
+          wofData.properties['wof:superseded_by'].length > 0;
 }
 
 function isCurrent(wofData) {

--- a/test/components/isActiveRecordTest.js
+++ b/test/components/isActiveRecordTest.js
@@ -30,16 +30,16 @@ tape('isActiveRecord', function(test) {
 
   });
 
-  test.test('undefined/blank edtf:superseded values should return true', function(t) {
+  test.test('undefined/non-array/zero-length wof:superseded_by should return true', function(t) {
     var input = [
-      { properties: { 'edtf:superseded': undefined } },
-      { properties: { 'edtf:superseded': '' } },
-      { properties: { 'edtf:superseded': ' \t ' } }
+      { properties: { 'wof:superseded_by': undefined } },
+      { properties: { 'wof:superseded_by': 'this is not an array' } },
+      { properties: { 'wof:superseded_by': [] } }
     ];
     var expected = [
-      { properties: { 'edtf:superseded': undefined } },
-      { properties: { 'edtf:superseded': '' } },
-      { properties: { 'edtf:superseded': ' \t ' } }
+      { properties: { 'wof:superseded_by': undefined } },
+      { properties: { 'wof:superseded_by': 'this is not an array' } },
+      { properties: { 'wof:superseded_by': [] } }
     ];
 
     test_stream(input, isActiveRecord.create(), function(err, actual) {
@@ -49,7 +49,7 @@ tape('isActiveRecord', function(test) {
 
   });
 
-  test.test('properties without edtf:superseded or edtf:deprecated or mz:is_current should return true', function(t) {
+  test.test('properties without wof:superseded_by or edtf:deprecated or mz:is_current should return true', function(t) {
     var input = [
       { properties: { } }
     ];
@@ -77,9 +77,9 @@ tape('isActiveRecord', function(test) {
 
   });
 
-  test.test('non-blank edtf:superseded values should return false', function(t) {
+  test.test('non-zero-length wof:superseded_by array should return false', function(t) {
     var input = [
-      { properties: { 'edtf:superseded': 'some value' } }
+      { properties: { 'wof:superseded_by': [1, 2] } }
     ];
     var expected = [];
 


### PR DESCRIPTION
Fixes pelias/pelias#413

The `wof:superseded_by` field is more reliable than the `edtf:superseded` field.  There are 789 neighbourhood records with a non-empty `wof:superseded_by` field but no `edtf:superseded` field.  