### PR TITLE
Make localized name extraction configurable (default:disabled)

### DIFF
--- a/src/components/extractFields.js
+++ b/src/components/extractFields.js
@@ -3,15 +3,27 @@
 var map = require('through2-map');
 var _ = require('lodash');
 var iso3166 = require('iso3166-1');
-const logger = require('pelias-logger').get('extractFields');
 
-module.exports.create = function() {
+const getDefaultName = require('./getDefaultName');
+const getLocalizedName = require('./getLocalizedName');
+
+
+/**
+ * Returns a data object with all fields filled in.
+ *
+ * @param {boolean} enableLocalizedNames
+ * @returns {object}
+ */
+module.exports.create = function(enableLocalizedNames) {
+
+  enableLocalizedNames = enableLocalizedNames || false;
+
   // this function extracts the id, name, placetype, hierarchy, and geometry
   return map.obj(function(wofData) {
     const res = {
       properties: {
         Id: wofData.properties['wof:id'],
-        Name: getName(wofData),
+        Name: getName(wofData, enableLocalizedNames),
         Placetype: wofData.properties['wof:placetype'],
         Hierarchy: wofData.properties['wof:hierarchy']
       },
@@ -45,100 +57,17 @@ function getAbbr(wofData) {
 }
 
 /**
- * Return the localized name or default name for the given record
+ * Return the name of the record based on which extraction strategy is preferred.
  *
  * @param {object} wofData
- * @returns {false|string}
+ * @param {boolean} enableLocalizedNames
+ * @returns {boolean|string}
  */
-function getName(wofData) {
-
-  // if this is a US county, use the qs:a2_alt for county
-  // eg - wof:name = 'Lancaster' and qs:a2_alt = 'Lancaster County', use latter
-  if (isUsCounty(wofData)) {
-    return getPropertyValue(wofData, 'qs:a2_alt');
+function getName(wofData, enableLocalizedNames) {
+  if (enableLocalizedNames === true) {
+    return getLocalizedName(wofData);
   }
-
-  // attempt to use the following in order of priority and fallback to wof:name if all else fails
-  return getLocalizedName(wofData, 'wof:lang_x_spoken') ||
-    getLocalizedName(wofData, 'wof:lang_x_official') ||
-    getLocalizedName(wofData, 'wof:lang') ||
-    getPropertyValue(wofData, 'wof:label') ||
-    getPropertyValue(wofData, 'wof:name');
-}
-
-// this function is used to verify that a US county QS altname is available
-function isUsCounty(wofData) {
-  return 'US' === wofData.properties['iso:country'] &&
-        'county' === wofData.properties['wof:placetype'] &&
-        !_.isUndefined(wofData.properties['qs:a2_alt']);
-}
-
-/**
- * Returns the property name of the name to be used
- * according to the language specification
- *
- * example:
- *  if wofData[langProperty] === ['rus']
- *  then return 'name:rus_x_preferred'
- *
- * example with multiple values:
- *  if wofData[langProperty] === ['rus','ukr','eng']
- *  then return 'name:rus_x_preferred'
- *
- * @param {object} wofData
- * @param {string} langProperty
- * @returns {string}
- */
-function getOfficialLangName(wofData, langProperty) {
-  var languages = wofData.properties[langProperty];
-
-  // convert to array in case it is just a string
-  if (!(languages instanceof Array)) {
-    languages = [languages];
-  }
-
-  if (languages.length > 1) {
-    logger.silly(`more than one ${langProperty} specified`,
-      wofData.properties['wof:lang_x_official'], languages);
-  }
-
-  // for now always just grab the first language in the array
-  return `name:${languages[0]}_x_preferred`;
-}
-
-/**
- * Given a language property name return the corresponding name:* property if one exists
- * and false if that can't be found for any reason
- *
- * @param {object} wofData
- * @param {string} langProperty
- * @returns {false|string}
- */
-function getLocalizedName(wofData, langProperty) {
-
-  // check that there is a value at the specified property and that it's not
-  // set to unknown or undefined
-  if (wofData.properties.hasOwnProperty(langProperty) &&
-      !_.isEmpty(wofData.properties[langProperty]) &&
-      wofData.properties[langProperty] !== 'unk' &&
-      wofData.properties[langProperty] !== 'und' &&
-      !_.isEqual(wofData.properties[langProperty], ['unk']) &&
-      !_.isEqual(wofData.properties[langProperty], ['und'])) {
-
-    // build the preferred lang key to use for name, like 'name:deu_x_preferred'
-    var official_lang_key = getOfficialLangName(wofData, langProperty);
-
-    // check if that language is available
-    var name = getPropertyValue(wofData, official_lang_key);
-    if (name) {
-      return name;
-    }
-
-    // if corresponding name property wasn't found, log the error
-    logger.warn(langProperty, '[missing]', official_lang_key, wofData.properties['wof:name'],
-      wofData.properties['wof:placetype'], wofData.properties['wof:id']);
-  }
-  return false;
+  return getDefaultName(wofData);
 }
 
 /**
@@ -146,7 +75,7 @@ function getLocalizedName(wofData, langProperty) {
  *
  * @param {object} wofData
  * @param {string} property
- * @returns {false|string}
+ * @returns {boolean|string}
  */
 function getPropertyValue(wofData, property) {
 

--- a/src/components/getDefaultName.js
+++ b/src/components/getDefaultName.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const _ = require('lodash');
+
+// this function is used to verify that a US county QS altname is available
+function isUsCounty(wofData) {
+  return 'US' === wofData.properties['iso:country'] &&
+    'county' === wofData.properties['wof:placetype'] &&
+    !_.isUndefined(wofData.properties['qs:a2_alt']);
+}
+
+// if this is a US county, use the qs:a2_alt for county
+// eg - wof:name = 'Lancaster' and qs:a2_alt = 'Lancaster County', use latter
+function getName(wofData) {
+  if (isUsCounty(wofData)) {
+    return wofData.properties['qs:a2_alt'];
+  }
+
+  if (wofData.properties.hasOwnProperty('wof:label')) {
+    return wofData.properties['wof:label'];
+  }
+
+  return wofData.properties['wof:name'];
+
+}
+
+module.exports = getName;

--- a/src/components/getLocalizedName.js
+++ b/src/components/getLocalizedName.js
@@ -1,0 +1,125 @@
+'use strict';
+
+const _ = require('lodash');
+const logger = require('pelias-logger').get('wof-pip-service');
+
+/**
+ * Return the localized name or default name for the given record
+ *
+ * @param {object} wofData
+ * @returns {false|string}
+ */
+function getName(wofData) {
+
+  // if this is a US county, use the qs:a2_alt for county
+  // eg - wof:name = 'Lancaster' and qs:a2_alt = 'Lancaster County', use latter
+  if (isUsCounty(wofData)) {
+    return getPropertyValue(wofData, 'qs:a2_alt');
+  }
+
+  // attempt to use the following in order of priority and fallback to wof:name if all else fails
+  return getLocalizedName(wofData, 'wof:lang_x_spoken') ||
+         getLocalizedName(wofData, 'wof:lang_x_official') ||
+         getLocalizedName(wofData, 'wof:lang') ||
+         getPropertyValue(wofData, 'wof:label') ||
+         getPropertyValue(wofData, 'wof:name');
+}
+
+// this function is used to verify that a US county QS altname is available
+function isUsCounty(wofData) {
+  return 'US' === wofData.properties['iso:country'] &&
+    'county' === wofData.properties['wof:placetype'] &&
+    !_.isUndefined(wofData.properties['qs:a2_alt']);
+}
+
+/**
+ * Returns the property name of the name to be used
+ * according to the language specification
+ *
+ * example:
+ *  if wofData[langProperty] === ['rus']
+ *  then return 'name:rus_x_preferred'
+ *
+ * example with multiple values:
+ *  if wofData[langProperty] === ['rus','ukr','eng']
+ *  then return 'name:rus_x_preferred'
+ *
+ * @param {object} wofData
+ * @param {string} langProperty
+ * @returns {string}
+ */
+function getOfficialLangName(wofData, langProperty) {
+  var languages = wofData.properties[langProperty];
+
+  // convert to array in case it is just a string
+  if (!(languages instanceof Array)) {
+    languages = [languages];
+  }
+
+  if (languages.length > 1) {
+    logger.silly(`more than one ${langProperty} specified`,
+      wofData.properties['wof:lang_x_official'], languages);
+  }
+
+  // for now always just grab the first language in the array
+  return `name:${languages[0]}_x_preferred`;
+}
+
+/**
+ * Given a language property name return the corresponding name:* property if one exists
+ * and false if that can't be found for any reason
+ *
+ * @param {object} wofData
+ * @param {string} langProperty
+ * @returns {false|string}
+ */
+function getLocalizedName(wofData, langProperty) {
+
+  // check that there is a value at the specified property and that it's not
+  // set to unknown or undefined
+  if (wofData.properties.hasOwnProperty(langProperty) &&
+    !_.isEmpty(wofData.properties[langProperty]) &&
+    wofData.properties[langProperty] !== 'unk' &&
+    wofData.properties[langProperty] !== 'und' &&
+    !_.isEqual(wofData.properties[langProperty], ['unk']) &&
+    !_.isEqual(wofData.properties[langProperty], ['und'])) {
+
+    // build the preferred lang key to use for name, like 'name:deu_x_preferred'
+    var official_lang_key = getOfficialLangName(wofData, langProperty);
+
+    // check if that language is available
+    var name = getPropertyValue(wofData, official_lang_key);
+    if (name) {
+      return name;
+    }
+
+    // if corresponding name property wasn't found, log the error
+    logger.warn(langProperty, '[missing]', official_lang_key, wofData.properties['wof:name'],
+      wofData.properties['wof:placetype'], wofData.properties['wof:id']);
+  }
+  return false;
+}
+
+/**
+ * Get the string value of the property or false if not found
+ *
+ * @param {object} wofData
+ * @param {string} property
+ * @returns {boolean|string}
+ */
+function getPropertyValue(wofData, property) {
+
+  if (wofData.properties.hasOwnProperty(property)) {
+
+    // if the value is an array, return the first item
+    if (wofData.properties[property] instanceof Array) {
+      return wofData.properties[property][0];
+    }
+
+    // otherwise just return the value as is
+    return wofData.properties[property];
+  }
+  return false;
+}
+
+module.exports = getName;

--- a/test/components/extractFieldsLocalizedNameTest.js
+++ b/test/components/extractFieldsLocalizedNameTest.js
@@ -1,0 +1,305 @@
+var tape = require('tape');
+var event_stream = require('event-stream');
+var extractFields = require('../../src/components/extractFields');
+
+
+function test_stream(input, testedStream, callback) {
+  var input_stream = event_stream.readArray(input);
+  var destination_stream = event_stream.writeArray(callback);
+
+  input_stream.pipe(testedStream).pipe(destination_stream);
+}
+
+tape('extractFields localized name tests', function(test) {
+
+  test.test('using wof:lang_x_spoken', function(t) {
+    var input = {
+      properties: {}
+    };
+    input.properties['wof:id'] = 17;
+    input.properties['wof:name'] = 'Feature name';
+    input.properties['wof:lang_x_spoken'] = ['rus'];
+    input.properties['name:rus_x_preferred'] = ['Russian name'];
+    input.properties['iso:country'] = 'RU';
+    input.properties['wof:placetype'] = 'someplacetype';
+    input.properties['wof:hierarchy'] = 'Feature hierarchy';
+
+    var expected = {
+      properties: {
+        Id: 17,
+        Name: 'Russian name',
+        Placetype: 'someplacetype',
+        Hierarchy: 'Feature hierarchy'
+      },
+      geometry: undefined
+    };
+
+    test_stream([input], extractFields.create(true), function(err, actual) {
+      t.deepEqual(actual, [expected], 'should be equal');
+      t.end();
+    });
+
+  });
+
+  test.test('using wof:lang_x_spoken, not an array', function(t) {
+    var input = {
+      properties: {}
+    };
+    input.properties['wof:id'] = 17;
+    input.properties['wof:name'] = 'Feature name';
+    input.properties['wof:lang_x_spoken'] = 'rus'; // <--- note that the language could be a single string
+    input.properties['name:rus_x_preferred'] = 'Russian name'; // <--- note that the name could be a single string
+    input.properties['iso:country'] = 'RU';
+    input.properties['wof:placetype'] = 'someplacetype';
+    input.properties['wof:hierarchy'] = 'Feature hierarchy';
+
+    var expected = {
+      properties: {
+        Id: 17,
+        Name: 'Russian name',
+        Placetype: 'someplacetype',
+        Hierarchy: 'Feature hierarchy'
+      },
+      geometry: undefined
+    };
+
+    test_stream([input], extractFields.create(true), function(err, actual) {
+      t.deepEqual(actual, [expected], 'should be equal');
+      t.end();
+    });
+
+  });
+
+  test.test('wof:lang_x_official === [unk]', function(t) {
+    var input = {
+      properties: {}
+    };
+    input.properties['wof:id'] = 17;
+    input.properties['wof:name'] = 'Feature name';
+    input.properties['wof:lang_x_official'] = ['unk'];
+    input.properties['name:rus_x_preferred'] = ['Russian name'];
+    input.properties['iso:country'] = 'RU';
+    input.properties['wof:placetype'] = 'someplacetype';
+    input.properties['wof:hierarchy'] = 'Feature hierarchy';
+
+    var expected = {
+      properties: {
+        Id: 17,
+        Name: 'Feature name',
+        Placetype: 'someplacetype',
+        Hierarchy: 'Feature hierarchy'
+      },
+      geometry: undefined
+    };
+
+    test_stream([input], extractFields.create(true), function(err, actual) {
+      t.deepEqual(actual, [expected], 'should be equal');
+      t.end();
+    });
+
+  });
+
+  test.test('wof:lang_x_official === und', function(t) {
+    var input = {
+      properties: {}
+    };
+    input.properties['wof:id'] = 17;
+    input.properties['wof:name'] = 'Feature name';
+    input.properties['wof:lang_x_official'] = 'und';
+    input.properties['name:rus_x_preferred'] = ['Russian name'];
+    input.properties['iso:country'] = 'RU';
+    input.properties['wof:placetype'] = 'someplacetype';
+    input.properties['wof:hierarchy'] = 'Feature hierarchy';
+
+    var expected = {
+      properties: {
+        Id: 17,
+        Name: 'Feature name',
+        Placetype: 'someplacetype',
+        Hierarchy: 'Feature hierarchy'
+      },
+      geometry: undefined
+    };
+
+    test_stream([input], extractFields.create(true), function(err, actual) {
+      t.deepEqual(actual, [expected], 'should be equal');
+      t.end();
+    });
+
+  });
+
+  test.test('using wof:lang_x_official', function(t) {
+    var input = {
+      properties: {}
+    };
+    input.properties['wof:id'] = 17;
+    input.properties['wof:name'] = 'Feature name';
+    input.properties['wof:lang_x_official'] = ['rus'];
+    input.properties['name:rus_x_preferred'] = ['Russian name'];
+    input.properties['iso:country'] = 'RU';
+    input.properties['wof:placetype'] = 'someplacetype';
+    input.properties['wof:hierarchy'] = 'Feature hierarchy';
+
+    var expected = {
+      properties: {
+        Id: 17,
+        Name: 'Russian name',
+        Placetype: 'someplacetype',
+        Hierarchy: 'Feature hierarchy'
+      },
+      geometry: undefined
+    };
+
+    test_stream([input], extractFields.create(true), function(err, actual) {
+      t.deepEqual(actual, [expected], 'should be equal');
+      t.end();
+    });
+
+  });
+
+  test.test('wof:lang_x_spoken has no name, fallback to official', function(t) {
+    var input = {
+      properties: {}
+    };
+    input.properties['wof:id'] = 17;
+    input.properties['wof:name'] = 'Feature name';
+    input.properties['wof:lang_x_spoken'] = ['eng'];
+    input.properties['wof:lang_x_official'] = ['rus'];
+    input.properties['name:rus_x_preferred'] = ['Russian name'];
+    input.properties['iso:country'] = 'RU';
+    input.properties['wof:placetype'] = 'someplacetype';
+    input.properties['wof:hierarchy'] = 'Feature hierarchy';
+
+    var expected = {
+      properties: {
+        Id: 17,
+        Name: 'Russian name',
+        Placetype: 'someplacetype',
+        Hierarchy: 'Feature hierarchy'
+      },
+      geometry: undefined
+    };
+
+    test_stream([input], extractFields.create(true), function(err, actual) {
+      t.deepEqual(actual, [expected], 'should be equal');
+      t.end();
+    });
+
+  });
+
+  test.test('wof:lang', function(t) {
+    var input = {
+      properties: {}
+    };
+    input.properties['wof:id'] = 17;
+    input.properties['wof:name'] = 'Feature name';
+    input.properties['wof:lang'] = ['rus'];
+    input.properties['name:rus_x_preferred'] = ['Russian name'];
+    input.properties['iso:country'] = 'RU';
+    input.properties['wof:placetype'] = 'someplacetype';
+    input.properties['wof:hierarchy'] = 'Feature hierarchy';
+
+    var expected = {
+      properties: {
+        Id: 17,
+        Name: 'Russian name',
+        Placetype: 'someplacetype',
+        Hierarchy: 'Feature hierarchy'
+      },
+      geometry: undefined
+    };
+
+    test_stream([input], extractFields.create(true), function(err, actual) {
+      t.deepEqual(actual, [expected], 'should be equal');
+      t.end();
+    });
+
+  });
+
+  test.test('fallback to wof:label', function(t) {
+    var input = {
+      properties: {}
+    };
+    input.properties['wof:id'] = 17;
+    input.properties['wof:name'] = 'Feature name';
+    input.properties['wof:label'] = 'Label name';
+    input.properties['wof:lang_x_spoken'] = ['eng'];
+    input.properties['wof:lang_x_official'] = ['rus'];
+    input.properties['iso:country'] = 'RU';
+    input.properties['wof:placetype'] = 'someplacetype';
+    input.properties['wof:hierarchy'] = 'Feature hierarchy';
+
+    var expected = {
+      properties: {
+        Id: 17,
+        Name: 'Label name',
+        Placetype: 'someplacetype',
+        Hierarchy: 'Feature hierarchy'
+      },
+      geometry: undefined
+    };
+
+    test_stream([input], extractFields.create(true), function(err, actual) {
+      t.deepEqual(actual, [expected], 'should be equal');
+      t.end();
+    });
+
+  });
+
+  test.test('fallback to wof:name', function(t) {
+    var input = {
+      properties: {}
+    };
+    input.properties['wof:id'] = 17;
+    input.properties['wof:name'] = 'Feature name';
+    input.properties['wof:lang_x_spoken'] = ['eng'];
+    input.properties['wof:lang_x_official'] = ['rus'];
+    input.properties['iso:country'] = 'RU';
+    input.properties['wof:placetype'] = 'someplacetype';
+    input.properties['wof:hierarchy'] = 'Feature hierarchy';
+
+    var expected = {
+      properties: {
+        Id: 17,
+        Name: 'Feature name',
+        Placetype: 'someplacetype',
+        Hierarchy: 'Feature hierarchy'
+      },
+      geometry: undefined
+    };
+
+    test_stream([input], extractFields.create(true), function(err, actual) {
+      t.deepEqual(actual, [expected], 'should be equal');
+      t.end();
+    });
+
+  });
+
+  test.test('wof:label is empty, fallback to wof:name', function(t) {
+    var input = {
+      properties: {}
+    };
+    input.properties['wof:id'] = 17;
+    input.properties['wof:name'] = 'Feature name';
+    input.properties['wof:label'] = '';
+    input.properties['iso:country'] = 'RU';
+    input.properties['wof:placetype'] = 'someplacetype';
+    input.properties['wof:hierarchy'] = 'Feature hierarchy';
+
+    var expected = {
+      properties: {
+        Id: 17,
+        Name: 'Feature name',
+        Placetype: 'someplacetype',
+        Hierarchy: 'Feature hierarchy'
+      },
+      geometry: undefined
+    };
+
+    test_stream([input], extractFields.create(true), function(err, actual) {
+      t.deepEqual(actual, [expected], 'should be equal');
+      t.end();
+    });
+
+  });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 require ('./serverTest.js');
 require ('./configValidationTest.js');
 require ('./components/extractFieldsTest.js');
+require ('./components/extractFieldsLocalizedNameTest.js');
 require ('./components/loadJSONTest.js');
 require ('./components/simplifyGeometryTest.js');
 require ('./components/isActiveRecordTest.js');


### PR DESCRIPTION
Putting the localized name extraction behind a flag that can be passed in at creation time.
By default, it is set to be disabled.

There was a mixup when we reverted and then re-reverted the code and a test file got lost. So adding that back in here.
